### PR TITLE
Fix#32: Change TEXT to VARCHAR for avatar columns to allow default va…

### DIFF
--- a/database/evaluation_db.sql
+++ b/database/evaluation_db.sql
@@ -295,7 +295,7 @@ CREATE TABLE `users` (
   `lastname` varchar(200) NOT NULL,
   `email` varchar(200) NOT NULL,
   `password` text NOT NULL,
-  `avatar` text NOT NULL DEFAULT 'no-image-available.png',
+  `avatar` varchar(255) NOT NULL DEFAULT 'no-image-available.png',
   `date_created` datetime NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/database/evaluation_db.sql
+++ b/database/evaluation_db.sql
@@ -153,7 +153,7 @@ CREATE TABLE `faculty_list` (
   `lastname` varchar(200) NOT NULL,
   `email` varchar(200) NOT NULL,
   `password` text NOT NULL,
-  `avatar` text NOT NULL DEFAULT 'no-image-available.png',
+  `avatar` varchar(255) NOT NULL DEFAULT 'no-image-available.png',
   `date_created` datetime NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -225,9 +225,10 @@ CREATE TABLE `student_list` (
   `email` varchar(200) NOT NULL,
   `password` text NOT NULL,
   `class_id` int(30) NOT NULL,
-  `avatar` text NOT NULL DEFAULT 'no-image-available.png',
+  `avatar` varchar(255) NOT NULL DEFAULT 'no-image-available.png',
   `date_created` datetime NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 
 --
 -- Dumping data for table `student_list`


### PR DESCRIPTION
…lues

## PR Description
- Modified `faculty_list` and `student_list` tables to use VARCHAR(255) for `avatar` column instead of TEXT.

- Ensured compatibility with MySQL/MariaDB constraints regarding default values for BLOB/TEXT columns.

Problem
![Screenshot (32)_LI](https://github.com/SaiyamTuteja/Faculty_Evaluation_System/assets/142904704/063d77c7-616d-4741-9946-c8f85e3db388)

Problem Solved
![Screenshot (31)_LI](https://github.com/SaiyamTuteja/Faculty_Evaluation_System/assets/142904704/e6934d69-20d6-4721-a0af-211d1a03f5e4)




## Related Issues: Issue for which you are raising a PR for

- Closes #32 

### Issue

#32 

### Checklist

- [x] I have gone through the [contributing guide](https://github.com/SaiyamTuteja/Faculty_Evaluation_System/blob/main/CONTRIBUTING.md)
- [x] I have updated my branch and synced it with project `main` branch before making this PR
- [x] Is this a bug fix/enhancement/documentation changes
- [x] Part of GSSOC
- [ ] Tested for any breaking changes
- [ ] Other relevant checks completed


## Undertaking

I declare that: 

1. The content I am submitting is original and has not been plagiarized.  
2. No portion of the work has been copied from any other source without proper attribution.  
3. The work has been checked for plagiarism, and I assure its authenticity.  

I understand that any violation of this undertaking may have legal consequences that I will bear and could result in the withdrawal of any recognition associated with the work. 

- [x] I Agree
